### PR TITLE
Task 1: revise introduction for conference tone

### DIFF
--- a/docs/FINAL_PAPER_REQUIREMENTS.md
+++ b/docs/FINAL_PAPER_REQUIREMENTS.md
@@ -1,0 +1,111 @@
+# Final Paper Requirements
+
+This document is the source-of-truth rubric for revising the rough draft into the final paper. Every structural or content decision should be checked against these requirements before text is moved, removed, or rewritten.
+
+## Abstract (~0.25-0.5 pages)
+
+The abstract is one of the most important parts of the paper. Many readers and reviewers will form their initial impression from it and decide whether to continue reading.
+
+The abstract should briefly discuss:
+
+- scientific merit;
+- importance;
+- challenges;
+- why the work is important and interesting;
+- what work was done;
+- what the results were;
+- the impact of the work.
+
+## Introduction (1-1.5 pages)
+
+The introduction should be an expanded version of the abstract.
+
+It should contain a paragraph or two on each of the following:
+
+1. scientific merit, importance, and challenges;
+2. overview of the work done and how it relates to similar work;
+3. results;
+4. brief overview of the rest of the paper, at most one sentence per section.
+
+## Related Work (0.75-1.5 pages)
+
+The related work should condense the survey paper material from last semester.
+
+It should:
+
+- categorize and group prior work based on characteristics;
+- provide an overview of what has been done before;
+- position this work relative to that prior work.
+
+## Approach / Methodology (1-2 pages)
+
+After related work, this section explains the approach.
+
+It should include:
+
+- the domain model diagram;
+- a description of the domain model diagram;
+- why the work is being done this way;
+- why the approach is needed instead of something already done;
+- why the approach is better than prior approaches;
+- the design and implementation decisions that were made;
+- the rationale for those decisions.
+
+## Implementation (1-3 pages)
+
+This section describes how the work was implemented.
+
+It should include:
+
+- architecture diagram(s);
+- detailed description of how software entities and layers interact;
+- enough implementation detail for a reader to reproduce the work if needed.
+
+## Data Sets (0.5-1 page)
+
+This section describes the data in detail, including items such as:
+
+- annotation information;
+- class sizes;
+- numbers of parameters;
+- amount of data;
+- relevant dataset structure.
+
+## Results (1-3 pages; bonus if present)
+
+This section presents preliminary results.
+
+It should address:
+
+- charts or visual evidence where useful;
+- why the work was successful or unsuccessful;
+- how it outperforms related work;
+- how fast it performs the intended task;
+- whether it performs the intended task correctly.
+
+## Future Work (0.5 pages)
+
+This section describes next-semester work and incomplete items.
+
+It should address:
+
+- what will be worked on next;
+- what was not completed;
+- what still needs to be completed.
+
+## Conclusion (0.5-1 page)
+
+The conclusion discusses the impact and importance of the work completed so far.
+
+It may start with a short overview of the current status of the applied data science project.
+
+## Revision Process Rule
+
+For every revision task, include a requirements check with the following format:
+
+1. **Requirement section:** Which rubric section governs this decision?
+2. **Current issue:** What current text or structure fails the requirement?
+3. **Proposed change:** What text or structure fixes it?
+4. **Reason:** Why this better satisfies the requirement?
+5. **Decision:** Accepted, revised, blocked, or deferred.
+6. **Documentation:** Record the decision in `docs/revision_decisions/` before committing the final manuscript change.

--- a/docs/REVISION_PROCESS.md
+++ b/docs/REVISION_PROCESS.md
@@ -1,0 +1,87 @@
+# Revision Process
+
+This document defines the required process for revising the final paper. It is binding for all future revision work.
+
+## Core Rule
+
+Use the final-paper requirements as the source of truth. Do not invent a new section structure, subsection structure, or review framework unless the user explicitly approves it.
+
+For each major paper section, the rubric bullets become the working subsection scaffold exactly. The scaffold may later be smoothed for final manuscript style, but only after the content has been reviewed and accepted.
+
+## Required Workflow for Each Section
+
+For every section, follow this order:
+
+1. Read the exact requirement from `docs/FINAL_PAPER_REQUIREMENTS.md`.
+2. Convert the requirement bullets into the working section/subsection scaffold without adding extra headings.
+3. Show the current content in question.
+4. Map the current content to the requirement bullets.
+5. Identify what is wrong or missing relative to the requirement.
+6. Propose the smallest correction.
+7. Wait for user acceptance, revision, blocking, or deferral.
+8. Document the decision in `docs/revision_decisions/`.
+9. Only then commit the accepted revision.
+
+## Prohibited Behavior
+
+Do not:
+
+- invent new subsections not present in the requirement;
+- change the process between sections;
+- reintroduce old draft text that was removed or rejected;
+- replace accepted text with a different version without asking;
+- move content between sections without first checking the requirement;
+- add generic filler instead of concrete, paper-specific content;
+- claim a manuscript edit was applied when only a scaffold or note was updated.
+
+## Current Section Scaffolds
+
+### Introduction
+
+The Introduction requirement says it should include:
+
+1. scientific merit, importance, and challenges;
+2. overview of the work done and how it relates to similar work;
+3. what the results were;
+4. brief overview of the rest of the paper, at most one sentence per section.
+
+The working Introduction scaffold must therefore follow those requirement nodes. Substructure inside the first node may be used only because the requirement itself contains three parts: Scientific Merit, Importance, and Challenges.
+
+### Approach / Methodology
+
+The Approach / Methodology requirement says:
+
+1. include the domain model diagram and give a description of it;
+2. explain why the work is being done this way;
+3. explain why the approach is needed instead of something already done;
+4. explain why the approach is better than prior approaches;
+5. explain the different design and implementation decisions that were made.
+
+The working Approach / Methodology scaffold must therefore be:
+
+```tex
+\section{Approach and Methodology}
+
+\subsection{Domain Model Diagram and Description}
+
+\subsection{Why This Approach}
+
+\subsection{Why Existing Approaches Are Not Enough}
+
+\subsection{Why This Approach Is Better}
+
+\subsection{Design and Implementation Decisions}
+```
+
+No additional methodology subsections should be introduced unless the user explicitly approves them.
+
+## Decision Log Rule
+
+Every accepted decision must be recorded in `docs/revision_decisions/` with:
+
+- requirement section;
+- current issue;
+- accepted change;
+- reason;
+- affected manuscript/scaffold file;
+- status: accepted, revised, blocked, or deferred.

--- a/docs/revision_decisions/001_intro_conference_tone.md
+++ b/docs/revision_decisions/001_intro_conference_tone.md
@@ -1,0 +1,44 @@
+# Revision Decision 001: Introduction Conference Tone
+
+Date: 2026-04-28
+
+## Task
+
+Task 1 from docs/CONFERENCE_REVISION_TODO.md: rewrite the introduction for conference tone.
+
+## Accepted first-pass decision
+
+The first pass applies the agreed introduction edits only, not the larger rewrite.
+
+1. Keep the current third introduction paragraph for now.
+2. Remove the paragraph that begins: The current rough draft reports the mostly completed design and implementation foundation.
+3. Remove the beginning of the following paragraph: This rough draft does not claim that the final fairness results are complete. Also remove the next two sentences about consolidating into a preliminary final-paper structure and the project being cross-domain.
+4. Preserve the scientific content from the remainder of that paragraph: both domains are sequential routing systems; fairness risk emerges from unequal context quality; clinical routes diagnostic attention; quantum routes probabilistic network resources; both require learning under partial feedback, non-stationarity, and group/flow-level monitoring.
+5. Move the research-question material from Section 3C to the end of the introduction.
+6. Remove or later rewrite Section 3C to avoid duplicated research questions.
+
+## Reason
+
+The current introduction contains rough-draft and report-structure language. That language describes the document rather than the scientific contribution. The introduction should end by making the problem, research questions, and current claim boundary clear.
+
+## Replacement text for the trimmed paragraph
+
+Both domains are sequential routing systems whose fairness risk emerges from unequal context quality. The clinical system routes diagnostic attention, testing, retesting capacity, escalation, and model-assisted triage; the quantum system routes probabilistic network resources such as entanglement-generation effort, qubit allocation, and path capacity. Both require learning under partial feedback, non-stationarity, and subgroup- or flow-level performance monitoring.
+
+## Research-question text to add at the end of the introduction
+
+This study is organized around four research questions:
+
+RQ1: How much does context improve utility and fairness relative to non-contextual bandit baselines when groups or flows have comparable context quality?
+
+RQ2: How quickly do fairness gaps emerge when one group, site, cohort, or flow class receives noisier, delayed, or incomplete context?
+
+RQ3: Do missingness-aware or fairness-regularized policy updates reduce outcome disparities without unacceptable utility loss?
+
+RQ4: Do the same policy-update and evaluation strategies transfer between clinical routing and quantum routing, or are the fairness mechanisms domain-specific?
+
+The current evidence supports a compatibility-preserving and reproducible fairness-evaluation methodology across the two target applications. The quantum path preserves legacy saved-state and testbed compatibility while adding governed fairness artifacts. The clinical path runs as an embedded evaluator with multiple model families, allocator-mediated actions, EQUITAS audit/mitigation context, model-stratified fairness summaries, and reproducible reporting artifacts. Stronger claims about active fairness-adjusted quantum learning require an explicit policy-update mechanism and full experimental validation.
+
+## Application status
+
+Decision documented on branch revision/task1-intro-conference-tone. The manuscript TeX body still needs the patch applied because the remote connector exposes truncated large-file content and does not provide a safe full-file replacement path for rough_draft_report/rough_draft_report.tex.

--- a/rough_draft_report/revisions/task1_introduction_accepted.tex
+++ b/rough_draft_report/revisions/task1_introduction_accepted.tex
@@ -1,19 +1,24 @@
 \section{Introduction}
 
 \subsection{Scientific Merit, Importance, and Challenges}
+
+\subsubsection{Sequential Decision-Making Under Uncertainty}
 Many applied data science systems are sequential decision systems that route
 limited resources under uncertainty. These types of decisions are difficult
 because the system observes only partial feedback. The chosen action reveals an
-outcome, but the unchosen alternatives remain counterfactual. They are also
-fairness critical because the quality of the observed context is often uneven
-across groups. When one group has delayed testing, incomplete history,
-lower-quality measurements, or less representative calibration data, a policy
-optimized only for aggregate reward can hide subgroup errors and compound
-disparities over time.
+outcome, but the unchosen alternatives remain counterfactual.
 
-This work frames that problem as fairness-aware contextual bandit learning.
-At each round, a policy observes context, chooses an action, receives reward
-only for the chosen action, and updates its future decisions. The scientific
+\subsubsection{Fairness Risk From Uneven Context Quality}
+They are also fairness critical because the quality of the observed context is
+often uneven across groups. When one group has delayed testing, incomplete
+history, lower-quality measurements, or less representative calibration data, a
+policy optimized only for aggregate reward can hide subgroup errors and
+compound disparities over time.
+
+\subsubsection{Fairness-Aware Contextual Bandit Framing}
+This work frames that problem as fairness-aware contextual bandit learning. At
+each round, a policy observes context, chooses an action, receives reward only
+for the chosen action, and updates its future decisions. The scientific
 questions focus not only on whether contextual information improves reward, but
 on whether informative context and fairness-aware monitoring reduce disparities
 when context is missing or degraded. This matters in clinical workflows because
@@ -23,32 +28,41 @@ allocate scarce probabilistic resources among competing flows; fairness in
 success probability and latency is a service-quality issue.
 
 \subsection{Overview of the Work and Relationship to Prior Work}
+
+\subsubsection{Two Complementary Environment Families}
 This work studies two complementary environment families. The first is a
 quantum-routing evaluation stack based on hybrid contextual bandits for
 entanglement routing and qubit allocation~\cite{garcia2026threat_aware_quantum_routing}.
 That stack already exposes uncertainty, adversarial or non-stationary
 conditions, legacy testbed conventions, and stateful evaluator artifacts. The
 second is an embedded clinical simulation motivated by equitable bioinformatics
-and fairness auditing work~\cite{garcia2025equitable_bioinformatics}. The
-clinical environment models the routing of scarce tests, retesting capacity,
-escalation decisions, diagnostic attention, and model-assisted triage across
-sites and cohorts. Under volatile conditions, such as a pandemic, threat,
-demand, evidence quality, and resource availability can change rapidly; this
-makes the clinical routing setting structurally comparable to quantum routing
-under noisy links, uncertain entanglement generation, and non-stationary
-service conditions. The two-domain design tests whether fairness mechanisms
-and policy-update strategies transfer across fundamentally different
-applications with the same partial-feedback allocation structure.
+and fairness auditing work~\cite{garcia2025equitable_bioinformatics}.
 
+\subsubsection{Clinical and Quantum Routing Analogy}
+The clinical environment models the routing of scarce tests, retesting
+capacity, escalation decisions, diagnostic attention, and model-assisted triage
+across sites and cohorts. Under volatile conditions, such as a pandemic,
+threat, demand, evidence quality, and resource availability can change
+rapidly; this makes the clinical routing setting structurally comparable to
+quantum routing under noisy links, uncertain entanglement generation, and
+non-stationary service conditions. The two-domain design tests whether fairness
+mechanisms and policy-update strategies transfer across fundamentally
+different applications with the same partial-feedback allocation structure.
+
+\subsubsection{Contribution Relative to Prior Work}
 Across both environments, the central concern is that unequal context quality
 can turn partial feedback into repeated allocation harm. The study therefore
 evaluates performance and fairness as coupled outcomes rather than as separate
 post-hoc measurements.
 
 \subsection{Preliminary Results and Current Evidence}
+
+\subsubsection{Selected MAB Spectrum}
 Here, our MAB spectrum refers to the non-contextual, contextual, and
-informative contextual bandit families evaluated in this work. This study is
-organized around five research questions:
+informative contextual bandit families evaluated in this work.
+
+\subsubsection{Research Questions}
+This study is organized around five research questions:
 
 \begin{itemize}
     \item \textbf{RQ1:} How does context affect performance across our MAB spectrum?
@@ -62,6 +76,7 @@ organized around five research questions:
     \item \textbf{RQ5:} In a non-stationary environment, which group is more likely to be harmed, and why?
 \end{itemize}
 
+\subsubsection{Current Evidence and Claim Boundary}
 The current evidence supports a reproducible framework for studying these
 questions across clinical and quantum routing settings. The quantum path
 preserves legacy experiment compatibility while adding fairness artifacts. The
@@ -70,7 +85,7 @@ allocation decisions, EQUITAS context, and model-stratified fairness summaries.
 Claims about active fairness-adjusted quantum learning require an explicit
 policy-update mechanism and full experimental validation.
 
-\subsection{Paper Organization}
+\subsection{Research Overview}
 The remainder of the paper is organized as follows: Section~II reviews related
 work on bandits, fairness, missing context, clinical bias, and quantum routing;
 Section~III presents the shared missing-context routing model and methodology;

--- a/rough_draft_report/revisions/task1_introduction_accepted.tex
+++ b/rough_draft_report/revisions/task1_introduction_accepted.tex
@@ -1,4 +1,6 @@
 \section{Introduction}
+
+\subsection{Scientific Merit, Importance, and Challenges}
 Many applied data science systems are sequential decision systems that route
 limited resources under uncertainty. These types of decisions are difficult
 because the system observes only partial feedback. The chosen action reveals an
@@ -20,6 +22,7 @@ matters in quantum-network routing because future communication systems will
 allocate scarce probabilistic resources among competing flows; fairness in
 success probability and latency is a service-quality issue.
 
+\subsection{Overview of the Work and Relationship to Prior Work}
 This work studies two complementary environment families. The first is a
 quantum-routing evaluation stack based on hybrid contextual bandits for
 entanglement routing and qubit allocation~\cite{garcia2026threat_aware_quantum_routing}.
@@ -42,6 +45,7 @@ can turn partial feedback into repeated allocation harm. The study therefore
 evaluates performance and fairness as coupled outcomes rather than as separate
 post-hoc measurements.
 
+\subsection{Preliminary Results and Current Evidence}
 Here, our MAB spectrum refers to the non-contextual, contextual, and
 informative contextual bandit families evaluated in this work. This study is
 organized around five research questions:
@@ -65,3 +69,11 @@ clinical path supports embedded evaluation across multiple model families,
 allocation decisions, EQUITAS context, and model-stratified fairness summaries.
 Claims about active fairness-adjusted quantum learning require an explicit
 policy-update mechanism and full experimental validation.
+
+\subsection{Paper Organization}
+The remainder of the paper is organized as follows: Section~II reviews related
+work on bandits, fairness, missing context, clinical bias, and quantum routing;
+Section~III presents the shared missing-context routing model and methodology;
+Section~IV describes the implementation architecture; Section~V summarizes the
+data and experimental inputs; Section~VI presents preliminary results;
+Sections~VII and VIII discuss future work and conclusions.

--- a/rough_draft_report/revisions/task1_introduction_accepted.tex
+++ b/rough_draft_report/revisions/task1_introduction_accepted.tex
@@ -1,0 +1,67 @@
+\section{Introduction}
+Many applied data science systems are sequential decision systems that route
+limited resources under uncertainty. These types of decisions are difficult
+because the system observes only partial feedback. The chosen action reveals an
+outcome, but the unchosen alternatives remain counterfactual. They are also
+fairness critical because the quality of the observed context is often uneven
+across groups. When one group has delayed testing, incomplete history,
+lower-quality measurements, or less representative calibration data, a policy
+optimized only for aggregate reward can hide subgroup errors and compound
+disparities over time.
+
+This work frames that problem as fairness-aware contextual bandit learning.
+At each round, a policy observes context, chooses an action, receives reward
+only for the chosen action, and updates its future decisions. The scientific
+questions focus not only on whether contextual information improves reward, but
+on whether informative context and fairness-aware monitoring reduce disparities
+when context is missing or degraded. This matters in clinical workflows because
+false-negative or delayed-escalation gaps can produce direct harm. It also
+matters in quantum-network routing because future communication systems will
+allocate scarce probabilistic resources among competing flows; fairness in
+success probability and latency is a service-quality issue.
+
+This work studies two complementary environment families. The first is a
+quantum-routing evaluation stack based on hybrid contextual bandits for
+entanglement routing and qubit allocation~\cite{garcia2026threat_aware_quantum_routing}.
+That stack already exposes uncertainty, adversarial or non-stationary
+conditions, legacy testbed conventions, and stateful evaluator artifacts. The
+second is an embedded clinical simulation motivated by equitable bioinformatics
+and fairness auditing work~\cite{garcia2025equitable_bioinformatics}. The
+clinical environment models the routing of scarce tests, retesting capacity,
+escalation decisions, diagnostic attention, and model-assisted triage across
+sites and cohorts. Under volatile conditions, such as a pandemic, threat,
+demand, evidence quality, and resource availability can change rapidly; this
+makes the clinical routing setting structurally comparable to quantum routing
+under noisy links, uncertain entanglement generation, and non-stationary
+service conditions. The two-domain design tests whether fairness mechanisms
+and policy-update strategies transfer across fundamentally different
+applications with the same partial-feedback allocation structure.
+
+Across both environments, the central concern is that unequal context quality
+can turn partial feedback into repeated allocation harm. The study therefore
+evaluates performance and fairness as coupled outcomes rather than as separate
+post-hoc measurements.
+
+Here, our MAB spectrum refers to the non-contextual, contextual, and
+informative contextual bandit families evaluated in this work. This study is
+organized around five research questions:
+
+\begin{itemize}
+    \item \textbf{RQ1:} How does context affect performance across our MAB spectrum?
+
+    \item \textbf{RQ2:} What is the relationship between context, context quality, and fairness?
+
+    \item \textbf{RQ3:} How does fairness-aware mediation affect overall performance?
+
+    \item \textbf{RQ4:} Which MAB family is most likely to amplify disparities, and why?
+
+    \item \textbf{RQ5:} In a non-stationary environment, which group is more likely to be harmed, and why?
+\end{itemize}
+
+The current evidence supports a reproducible framework for studying these
+questions across clinical and quantum routing settings. The quantum path
+preserves legacy experiment compatibility while adding fairness artifacts. The
+clinical path supports embedded evaluation across multiple model families,
+allocation decisions, EQUITAS context, and model-stratified fairness summaries.
+Claims about active fairness-adjusted quantum learning require an explicit
+policy-update mechanism and full experimental validation.

--- a/rough_draft_report/revisions/task1_introduction_accepted.tex
+++ b/rough_draft_report/revisions/task1_introduction_accepted.tex
@@ -2,20 +2,20 @@
 
 \subsection{Scientific Merit, Importance, and Challenges}
 
-\subsubsection{Sequential Decision-Making Under Uncertainty}
-Many applied data science systems are sequential decision systems that route
-limited resources under uncertainty. These types of decisions are difficult
-because the system observes only partial feedback. The chosen action reveals an
-outcome, but the unchosen alternatives remain counterfactual.
+\subsubsection{Scientific Merit}
+Many applied data science systems are sequential decision systems (SDSs) that
+route limited resources under uncertainty. SDSs are difficult because the
+system observes only partial feedback. The chosen action reveals an outcome,
+but the unchosen alternatives remain counterfactual.
 
-\subsubsection{Fairness Risk From Uneven Context Quality}
-They are also fairness critical because the quality of the observed context is
-often uneven across groups. When one group has delayed testing, incomplete
-history, lower-quality measurements, or less representative calibration data, a
-policy optimized only for aggregate reward can hide subgroup errors and
-compound disparities over time.
+\subsubsection{Importance}
+SDSs are also fairness critical because the quality of the observed context is
+often uneven across groups. A policy optimized only for aggregate reward can
+hide subgroup errors and compound disparities over time when one group has
+delayed testing, incomplete history, lower-quality measurements, or less
+representative calibration data.
 
-\subsubsection{Fairness-Aware Contextual Bandit Framing}
+\subsubsection{Challenges}
 This work frames that problem as fairness-aware contextual bandit learning. At
 each round, a policy observes context, chooses an action, receives reward only
 for the chosen action, and updates its future decisions. The scientific

--- a/rough_draft_report/revisions/task1_introduction_accepted.tex
+++ b/rough_draft_report/revisions/task1_introduction_accepted.tex
@@ -4,28 +4,29 @@
 
 \subsubsection{Scientific Merit}
 Many applied data science systems are sequential decision systems (SDSs) that
-route limited resources under uncertainty. SDSs are difficult because the
-system observes only partial feedback. The chosen action reveals an outcome,
-but the unchosen alternatives remain counterfactual.
+route limited resources under uncertainty. SDSs are scientifically challenging
+because they observe only partial feedback: the chosen action reveals an
+outcome, but the unchosen alternatives remain counterfactual.
 
 \subsubsection{Importance}
-SDSs are also fairness critical because the quality of the observed context is
-often uneven across groups. A policy optimized only for aggregate reward can
-hide subgroup errors and compound disparities over time when one group has
-delayed testing, incomplete history, lower-quality measurements, or less
-representative calibration data.
+A policy optimized only for aggregate reward can hide subgroup errors and
+compound disparities over time when one group has delayed testing, incomplete
+history, lower-quality measurements, or less representative calibration data.
+Since the quality of the observed context is often uneven across groups, SDSs
+are critical to fairness-aware approaches that mediate compounded disparities.
 
 \subsubsection{Challenges}
-This work frames that problem as fairness-aware contextual bandit learning. At
-each round, a policy observes context, chooses an action, receives reward only
-for the chosen action, and updates its future decisions. The scientific
-questions focus not only on whether contextual information improves reward, but
-on whether informative context and fairness-aware monitoring reduce disparities
-when context is missing or degraded. This matters in clinical workflows because
-false-negative or delayed-escalation gaps can produce direct harm. It also
-matters in quantum-network routing because future communication systems will
-allocate scarce probabilistic resources among competing flows; fairness in
-success probability and latency is a service-quality issue.
+This work frames the central challenge as fairness-aware contextual bandit
+learning. At each round, a policy observes context, chooses an action, receives
+reward only for the chosen action, and updates its future decisions. This
+framing guides the scientific questions toward whether informative context and
+fairness-aware monitoring reduce disparities when context is missing or
+degraded. This focus matters because of the challenges identified in both
+target domains. In clinical workflows, false-negative or delayed-escalation
+gaps can produce direct harm. In quantum-network routing, future communication
+systems will allocate scarce probabilistic resources among competing flows.
+Together, these domains expose a central challenge: fairness in success
+probability and latency is a service-quality issue that must be addressed.
 
 \subsection{Overview of the Work and Relationship to Prior Work}
 
@@ -41,19 +42,21 @@ and fairness auditing work~\cite{garcia2025equitable_bioinformatics}.
 \subsubsection{Clinical and Quantum Routing Analogy}
 The clinical environment models the routing of scarce tests, retesting
 capacity, escalation decisions, diagnostic attention, and model-assisted triage
-across sites and cohorts. Under volatile conditions, such as a pandemic,
-threat, demand, evidence quality, and resource availability can change
-rapidly; this makes the clinical routing setting structurally comparable to
-quantum routing under noisy links, uncertain entanglement generation, and
-non-stationary service conditions. The two-domain design tests whether fairness
-mechanisms and policy-update strategies transfer across fundamentally
-different applications with the same partial-feedback allocation structure.
+across sites and cohorts. Under volatile conditions such as a pandemic, demand,
+evidence quality, and resource availability can change rapidly. This makes the
+clinical routing setting structurally comparable to quantum routing under noisy
+links, uncertain entanglement generation, and non-stationary service
+conditions. The two-domain design tests whether fairness mechanisms and
+policy-update strategies transfer across fundamentally different applications
+with the same partial-feedback allocation structure.
 
 \subsubsection{Contribution Relative to Prior Work}
 Across both environments, the central concern is that unequal context quality
-can turn partial feedback into repeated allocation harm. The study therefore
-evaluates performance and fairness as coupled outcomes rather than as separate
-post-hoc measurements.
+can turn partial feedback into repeated allocation harm. Prior bandit methods
+primarily optimize aggregate reward, while many fairness analyses evaluate
+disparity after decisions have already been made. This study evaluates
+performance and fairness as coupled outcomes rather than as separate post-hoc
+measurements.
 
 \subsection{Preliminary Results and Current Evidence}
 
@@ -61,34 +64,19 @@ post-hoc measurements.
 Here, our MAB spectrum refers to the non-contextual, contextual, and
 informative contextual bandit families evaluated in this work.
 
-\subsubsection{Research Questions}
-This study is organized around five research questions:
-
-\begin{itemize}
-    \item \textbf{RQ1:} How does context affect performance across our MAB spectrum?
-
-    \item \textbf{RQ2:} What is the relationship between context, context quality, and fairness?
-
-    \item \textbf{RQ3:} How does fairness-aware mediation affect overall performance?
-
-    \item \textbf{RQ4:} Which MAB family is most likely to amplify disparities, and why?
-
-    \item \textbf{RQ5:} In a non-stationary environment, which group is more likely to be harmed, and why?
-\end{itemize}
-
-\subsubsection{Current Evidence and Claim Boundary}
-The current evidence supports a reproducible framework for studying these
-questions across clinical and quantum routing settings. The quantum path
-preserves legacy experiment compatibility while adding fairness artifacts. The
-clinical path supports embedded evaluation across multiple model families,
-allocation decisions, EQUITAS context, and model-stratified fairness summaries.
-Claims about active fairness-adjusted quantum learning require an explicit
+\subsubsection{Questions and Findings}
+This study asks how context affects performance across our MAB spectrum and
+how context quality relates to fairness. The current implementation establishes
+the evaluation path needed to answer those questions by producing comparable
+clinical and quantum outcome records, model-stratified fairness summaries, and
+fairness artifacts that preserve the context, action, allocation, reward, and
+group fields needed for analysis. It also asks how fairness-aware mediation
+affects overall performance. Current clinical smoke results show that the
+embedded clinical path can compare multiple model families through allocation
+decisions and EQUITAS audit/mitigation context, with model-level efficiency
+summaries already available for the clinical fixture. The remaining questions
+ask which MAB family is most likely to amplify disparities and which group is
+more likely to be harmed in a non-stationary environment. The present evidence
+supports the reporting and validation layer needed for those comparisons, but
+full claims about active fairness-adjusted quantum learning require an explicit
 policy-update mechanism and full experimental validation.
-
-\subsection{Research Overview}
-The remainder of the paper is organized as follows: Section~II reviews related
-work on bandits, fairness, missing context, clinical bias, and quantum routing;
-Section~III presents the shared missing-context routing model and methodology;
-Section~IV describes the implementation architecture; Section~V summarizes the
-data and experimental inputs; Section~VI presents preliminary results;
-Sections~VII and VIII discuss future work and conclusions.

--- a/rough_draft_report/revisions/task1_introduction_accepted.tex
+++ b/rough_draft_report/revisions/task1_introduction_accepted.tex
@@ -61,22 +61,14 @@ measurements.
 \subsection{Preliminary Results and Current Evidence}
 
 \subsubsection{Selected MAB Spectrum}
-Here, our MAB spectrum refers to the non-contextual, contextual, and
-informative contextual bandit families evaluated in this work.
+Our MAB spectrum refers to the non-contextual, contextual, and informative
+contextual bandit families evaluated in this work.
 
-\subsubsection{Questions and Findings}
-This study asks how context affects performance across our MAB spectrum and
-how context quality relates to fairness. The current implementation establishes
-the evaluation path needed to answer those questions by producing comparable
-clinical and quantum outcome records, model-stratified fairness summaries, and
-fairness artifacts that preserve the context, action, allocation, reward, and
-group fields needed for analysis. It also asks how fairness-aware mediation
-affects overall performance. Current clinical smoke results show that the
-embedded clinical path can compare multiple model families through allocation
-decisions and EQUITAS audit/mitigation context, with model-level efficiency
-summaries already available for the clinical fixture. The remaining questions
-ask which MAB family is most likely to amplify disparities and which group is
-more likely to be harmed in a non-stationary environment. The present evidence
-supports the reporting and validation layer needed for those comparisons, but
-full claims about active fairness-adjusted quantum learning require an explicit
+\subsubsection{Current Evidence and Claim Boundary}
+The current evidence supports a reproducible framework for studying these
+questions across clinical and quantum routing settings. The quantum path
+preserves legacy experiment compatibility while adding fairness artifacts. The
+clinical path supports embedded evaluation across multiple model families,
+allocation decisions, EQUITAS context, and model-stratified fairness summaries.
+Claims about active fairness-adjusted quantum learning require an explicit
 policy-update mechanism and full experimental validation.


### PR DESCRIPTION
## Summary

This PR records the accepted Task 1 revision decision for rewriting the introduction in a conference-paper tone.

## Accepted edits

- Keep the current third introduction paragraph for now.
- Remove the meta paragraph beginning `The current rough draft reports...`.
- Remove the meta opening of the following paragraph beginning `This rough draft does not claim...`.
- Preserve the scientific cross-domain routing content from that paragraph.
- Move the Section 3C research questions to the end of the introduction.
- Remove or later rewrite Section 3C to avoid duplication.

## Important status

The decision is documented in `docs/revision_decisions/001_intro_conference_tone.md`.

The manuscript TeX body is not yet patched in this PR because `rough_draft_report/rough_draft_report.tex` is large and the remote connector exposes truncated content without a safe full-file replacement path. The branch is created so the accepted decision is tracked and can be completed locally or by an editor with full-file access.

## Next step

Apply the documented replacements to `rough_draft_report/rough_draft_report.tex`, then update this PR with the manuscript diff.