### PR TITLE
Add endterm Beamer presentation with COVID clinical evidence

### DIFF
--- a/presentation/final_presentation.tex
+++ b/presentation/final_presentation.tex
@@ -1,0 +1,376 @@
+\documentclass[aspectratio=169,10pt]{beamer}
+
+\usetheme{Madrid}
+\usecolortheme{default}
+\setbeamertemplate{navigation symbols}{}
+\setbeamertemplate{footline}[frame number]
+
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta,positioning,fit,calc}
+\usepackage{pgfplots}
+\pgfplotsset{compat=1.18}
+
+\title[Fairness-Aware Routing]{Fairness-Aware Routing Under Missing Context}
+\subtitle{Multi-Armed, Contextual, and Informative Bandit Methods for Clinical and Quantum Settings}
+\author[P. Z. Garcia]{Piter Z. Garcia Bautista}
+\institute[RIT]{Rochester Institute of Technology\\MS Data Science / Decision-Making \& Algorithmic Fairness}
+\date{DSCI 601 Final Presentation}
+
+\definecolor{ritorange}{RGB}{247,105,2}
+\definecolor{deepblue}{RGB}{31,78,121}
+\definecolor{softgreen}{RGB}{72,160,98}
+\definecolor{softred}{RGB}{190,75,72}
+\definecolor{softgray}{RGB}{245,247,250}
+
+\setbeamercolor{title}{fg=deepblue}
+\setbeamercolor{frametitle}{fg=deepblue}
+\setbeamercolor{structure}{fg=ritorange}
+
+\newcommand{\mab}{\textsc{MAB}}
+\newcommand{\cmab}{\textsc{CMAB}}
+\newcommand{\icmab}{\textsc{iCMAB}}
+\newcommand{\sds}{\textsc{SDS}}
+
+\begin{document}
+
+% -----------------------------------------------------------------------------
+\begin{frame}
+  \titlepage
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Presentation Roadmap}
+\begin{enumerate}
+    \item Problem: sequential decisions under missing context
+    \item Real-world grounding: COVID test allocation and pulse oximetry bias
+    \item Proposed approach: fair contextual bandits over a selected MAB spectrum
+    \item Framework: clinical and quantum routing through a shared evaluator
+    \item Preliminary evidence, validation, and next work
+\end{enumerate}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Scientific Merit: Sequential Decision Systems}
+\begin{block}{Core setting}
+Many applied data science systems are \textbf{sequential decision systems (SDSs)} that route scarce resources under uncertainty.
+\end{block}
+
+\vspace{0.5em}
+\begin{columns}[T]
+\begin{column}{0.48\textwidth}
+\textbf{Clinical examples}
+\begin{itemize}
+    \item Which patient receives a scarce diagnostic test?
+    \item Which case is escalated or retested?
+    \item Which model/pipeline should be trusted?
+\end{itemize}
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Quantum examples}
+\begin{itemize}
+    \item Which route receives entanglement-generation effort?
+    \item Which path receives scarce qubit capacity?
+    \item Which allocator performs best under noisy links?
+\end{itemize}
+\end{column}
+\end{columns}
+
+\vspace{0.5em}
+\alert{Challenge:} the chosen action reveals an outcome, but unchosen alternatives remain counterfactual.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Why Context Matters for Fairness}
+\begin{block}{Failure mode}
+A policy optimized only for aggregate reward can hide subgroup errors and compound disparities over time when one group has delayed testing, incomplete history, lower-quality measurements, or less representative calibration data.
+\end{block}
+
+\vspace{0.5em}
+\begin{center}
+\begin{tikzpicture}[node distance=1.2cm, every node/.style={align=center}]
+\node[draw, rounded corners, fill=softgray, minimum width=2.8cm, minimum height=0.8cm] (ctx) {Uneven\\context quality};
+\node[draw, rounded corners, fill=softgray, right=1.2cm of ctx, minimum width=2.8cm, minimum height=0.8cm] (learn) {Partial-feedback\\learning};
+\node[draw, rounded corners, fill=softgray, right=1.2cm of learn, minimum width=2.8cm, minimum height=0.8cm] (alloc) {Repeated\\allocation};
+\node[draw, rounded corners, fill=softred!18, right=1.2cm of alloc, minimum width=2.8cm, minimum height=0.8cm] (harm) {Compounded\\disparity};
+\draw[-{Stealth}, thick] (ctx) -- (learn);
+\draw[-{Stealth}, thick] (learn) -- (alloc);
+\draw[-{Stealth}, thick] (alloc) -- (harm);
+\end{tikzpicture}
+\end{center}
+
+\vspace{0.4em}
+\textbf{Research idea:} treat context, performance, and fairness as coupled outcomes in the same sequential decision process.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Real-World Grounding: COVID Test Allocation}
+\begin{columns}[T]
+\begin{column}{0.54\textwidth}
+\textbf{Claim 1: Missing or ignored allocation context}
+\begin{itemize}
+    \item Early COVID-19 testing resources were scarce.
+    \item Allocation failed to adequately incorporate vulnerability context: race/ethnicity, SVI, burden, and access barriers.
+    \item Result: mismatch between testing access and community need.
+\end{itemize}
+\end{column}
+\begin{column}{0.42\textwidth}
+\begin{block}{Key quantitative finding}
+For every \textbf{1 percentage-point} increase in Hispanic underrepresentation in testing-site ZIP codes, the Hispanic share of COVID-19 deaths in later weeks was approximately \textbf{1.04 percentage points higher} than expected.
+\end{block}
+\end{column}
+\end{columns}
+
+\vspace{0.6em}
+\footnotesize Sources summarized in \texttt{docs/covid\_context\_case\_studies.md}: Bilal et al. (2021), Escobar et al. (2021), CDC MMWR, CDC SVI, Landes et al. (2020).
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{COVID Test Allocation as a Bandit Problem}
+\begin{columns}[T]
+\begin{column}{0.48\textwidth}
+\textbf{Decision unit}
+\begin{itemize}
+    \item Community node: ZIP code, county, or service region
+    \item Context: cases, deaths, positivity, race/ethnicity, SVI, poverty, crowding, age, essential-worker share
+    \item Arm: testing allocation level
+\end{itemize}
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Evaluation}
+\begin{itemize}
+    \item Reward: infections detected or deaths-averted proxy
+    \item Fairness: tests per 1,000, tests per detected case, disparity ratio by group/SVI
+    \item Risk: non-contextual allocation can reproduce convenience-based inequity
+\end{itemize}
+\end{column}
+\end{columns}
+
+\vspace{0.8em}
+\begin{center}
+\small
+\begin{tabular}{lll}
+\toprule
+Policy & Uses context? & Uses fairness signal? \\
+\midrule
+Non-contextual baseline & No & No \\
+Contextual utility-only & Yes & No \\
+Fairness-aware \icmab & Yes & Yes \\
+\bottomrule
+\end{tabular}
+\end{center}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Real-World Grounding: Pulse Oximetry Bias}
+\begin{columns}[T]
+\begin{column}{0.55\textwidth}
+\textbf{Claim 2: Missing group context at evaluation time}
+\begin{itemize}
+    \item Pulse oximetry was widely used for COVID triage and monitoring.
+    \item Devices overestimated oxygen saturation more often in darker-skinned patients.
+    \item This produced occult hypoxemia and delayed treatment eligibility.
+\end{itemize}
+\end{column}
+\begin{column}{0.41\textwidth}
+\begin{block}{Empirical pattern}
+Black patients were reported as roughly \textbf{3 times more likely} than White patients to have occult hypoxemia in the original NEJM evidence base.
+\end{block}
+\begin{block}{Scale}
+Later work included \textbf{24,504} patients with paired SpO$_2$/SaO$_2$ measurements.
+\end{block}
+\end{column}
+\end{columns}
+
+\vspace{0.4em}
+\footnotesize Sources summarized in \texttt{docs/covid\_context\_case\_studies.md}: Sjoding et al. (2020), Fawzy et al. (2022, 2023), Valbuena et al. (2022), VA ESP (2022), Gottlieb et al. (2022).
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Pulse Oximetry as a Bandit Problem}
+\begin{columns}[T]
+\begin{column}{0.48\textwidth}
+\textbf{Decision unit}
+\begin{itemize}
+    \item Patient encounter
+    \item Context: SpO$_2$, respiratory rate, heart rate, work of breathing, race/ethnicity, comorbidities
+    \item Arms: treat now, watch/wait, order confirmatory ABG
+\end{itemize}
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Evaluation}
+\begin{itemize}
+    \item Reward: correct and timely treatment decisions
+    \item Fairness: group-wise occult hypoxemia rate
+    \item Constraint target: reduce disparity in missed hypoxemia across groups
+\end{itemize}
+\end{column}
+\end{columns}
+
+\vspace{0.6em}
+\begin{equation*}
+\text{GWOHR}_g = P(\text{occult hypoxemia not caught} \mid \text{group}=g)
+\end{equation*}
+\begin{equation*}
+\max_g \text{GWOHR}_g - \min_g \text{GWOHR}_g \leq \epsilon
+\end{equation*}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Selected MAB Spectrum}
+\begin{block}{Spectrum evaluated in this work}
+Our MAB spectrum refers to the non-contextual, contextual, and informative contextual bandit families evaluated in the framework.
+\end{block}
+
+\vspace{0.5em}
+\begin{center}
+\begin{tabular}{p{0.23\textwidth}p{0.29\textwidth}p{0.34\textwidth}}
+\toprule
+Family & Decision signal & Expected risk under missing context \\
+\midrule
+\mab & action history only & may reinforce historical allocation bias \\
+\cmab & observed context & improves utility but can inherit biased or incomplete context \\
+\icmab & observed context + missingness/fairness information & tests whether context recovery and fairness mediation reduce harm \\
+\bottomrule
+\end{tabular}
+\end{center}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Shared Domain Model}
+\begin{center}
+\begin{tikzpicture}[
+  node distance=1.0cm,
+  box/.style={draw, rounded corners, align=center, minimum width=2.45cm, minimum height=0.75cm, fill=softgray},
+  bad/.style={draw, rounded corners, align=center, minimum width=2.45cm, minimum height=0.75cm, fill=softred!18},
+  good/.style={draw, rounded corners, align=center, minimum width=2.45cm, minimum height=0.75cm, fill=softgreen!18}
+]
+\node[box] (env) {Environment\\clinical / quantum};
+\node[bad, right=0.8cm of env] (ctx) {Missing, noisy,\\delayed context};
+\node[box, right=0.8cm of ctx] (policy) {Policy family\\\mab / \cmab / \icmab};
+\node[box, right=0.8cm of policy] (action) {Routing\\action};
+\node[good, below=0.9cm of action] (outcome) {Reward +\\fairness state};
+\node[box, left=0.8cm of outcome] (report) {Model-stratified\\reporting};
+\draw[-{Stealth}, thick] (env) -- (ctx);
+\draw[-{Stealth}, thick] (ctx) -- (policy);
+\draw[-{Stealth}, thick] (policy) -- (action);
+\draw[-{Stealth}, thick] (action) -- (outcome);
+\draw[-{Stealth}, thick] (outcome) -- (report);
+\draw[-{Stealth}, thick, dashed] (report.west) to[bend right=30] (policy.south);
+\end{tikzpicture}
+\end{center}
+
+\vspace{0.5em}
+\textbf{Key point:} the same failure mechanism appears in both domains: context quality determines what the learner can see, what it chooses, and which groups absorb the harm.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Framework Contribution}
+\begin{columns}[T]
+\begin{column}{0.48\textwidth}
+\textbf{Quantum path}
+\begin{itemize}
+    \item Preserves legacy quantum testbed and saved-state conventions.
+    \item Adds governed fairness artifacts through a sidecar/compatibility path.
+    \item Supports fairness evaluation without breaking existing quantum runs.
+\end{itemize}
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Clinical path}
+\begin{itemize}
+    \item Runs as embedded evaluator: environment, runner, allocator, model registry, EQUITAS mediation.
+    \item Supports multiple clinical model families.
+    \item Produces model-stratified fairness summaries and report artifacts.
+\end{itemize}
+\end{column}
+\end{columns}
+
+\vspace{0.7em}
+\begin{block}{Contribution}
+A reproducible framework for comparing context, fairness, and performance across two structurally similar but domain-distinct routing systems.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Preliminary Framework Evidence}
+\begin{center}
+\begin{tabular}{p{0.42\textwidth}p{0.42\textwidth}}
+\toprule
+Evidence item & Status / finding \\
+\midrule
+Clinical embedded path & runs through evaluator, runner, environment, allocator, models, and EQUITAS context \\
+Clinical fairness smoke & produced 16 fairness states across Oracle, ClinicalBaseline, FairAllocatorV1, and ClinicalBanditUCB \\
+Non-oracle clinical efficiency & FairAllocatorV1: 91.23\%; ClinicalBanditUCB: 84.21\%; ClinicalBaseline: 75.09\% oracle efficiency \\
+Reporting layer & generated model-stratified fairness summaries and manifest-linked artifacts \\
+Quantum compatibility & legacy quantum path preserved while fairness artifacts are attached \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\vspace{0.4em}
+\small These are preliminary framework-validation results; active fairness-adjusted quantum learning still requires an explicit policy-update mechanism and full validation.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{What the New COVID Analysis Adds}
+\begin{block}{Before}
+The project had a framework and cross-domain analogy, but the clinical motivation needed stronger empirical grounding.
+\end{block}
+
+\begin{block}{Now}
+The COVID case-study analysis supplies two concrete, evidence-backed clinical routing failures:
+\begin{enumerate}
+    \item test allocation failed when risk and vulnerability context were ignored;
+    \item pulse oximetry failed when group/skin-tone context was missing from calibration and evaluation.
+\end{enumerate}
+\end{block}
+
+\begin{block}{Impact on presentation and paper}
+These cases make the clinical side real: missing context is not abstract; it caused measurable access, mortality, diagnostic, and treatment-delay harms.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Next Work}
+\begin{enumerate}
+    \item Convert COVID test-allocation and pulse-ox case studies into executable clinical environments.
+    \item Generate the planned figures: allocation network, group access bars, occult hypoxemia bars, bias bars, and fairness--utility tradeoff curve.
+    \item Complete model-family comparisons across the selected MAB spectrum.
+    \item Quantify which group is more likely to be harmed under non-stationary conditions.
+    \item Implement and validate active fairness-adjusted quantum policy updates.
+\end{enumerate}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Takeaway}
+\begin{block}{Main claim}
+Context quality is a fairness variable. When context is missing, ignored, or unevenly distributed, sequential decision systems can convert measurement gaps into repeated allocation harm.
+\end{block}
+
+\begin{block}{Project contribution}
+This work builds a clinical--quantum evaluation framework that compares performance and fairness across the selected MAB spectrum while preserving reproducibility and model-stratified evidence.
+\end{block}
+
+\begin{block}{Why it matters}
+The same methodology can study COVID test allocation, biased diagnostic triage, and quantum routing under scarce probabilistic resources.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}[allowframebreaks]{Selected References}
+\scriptsize
+\begin{thebibliography}{99}
+\bibitem{bilal2021} Bilal et al. Racial and ethnic inequities in the early distribution of U.S. COVID-19 testing sites. \textit{Social Science \& Medicine}, 2021.
+\bibitem{escobar2021} Escobar et al. Addressing COVID-19 testing inequities among underserved communities. 2021.
+\bibitem{sjoding2020} Sjoding et al. Racial bias in pulse oximetry measurement. \textit{New England Journal of Medicine}, 2020.
+\bibitem{fawzy2022} Fawzy et al. Racial and ethnic discrepancy in pulse oximetry and delayed identification of treatment eligibility among patients with COVID-19. \textit{JAMA Internal Medicine}, 2022.
+\bibitem{fawzy2023} Fawzy et al. Clinical outcomes associated with overestimation of oxygen saturation by pulse oximetry. \textit{JAMA Network Open}, 2023.
+\bibitem{valbuena2022} Valbuena et al. Racial bias and reproducibility in pulse oximetry among medical and surgical inpatients in general care. \textit{BMJ}, 2022.
+\bibitem{garcia2026} Garcia Bautista. Threat-aware quantum routing evaluation / DSCI601 project materials, 2026.
+\end{thebibliography}
+\end{frame}
+
+\end{document}

--- a/presentation/final_presentation.tex
+++ b/presentation/final_presentation.tex
@@ -9,22 +9,25 @@
 \usepackage[utf8]{inputenc}
 \usepackage{amsmath,amssymb}
 \usepackage{booktabs}
+\usepackage{array}
 \usepackage{tikz}
-\usetikzlibrary{arrows.meta,positioning,fit,calc}
+\usetikzlibrary{arrows.meta,positioning,fit,calc,shapes.geometric}
 \usepackage{pgfplots}
 \pgfplotsset{compat=1.18}
 
 \title[Fairness-Aware Routing]{Fairness-Aware Routing Under Missing Context}
-\subtitle{Multi-Armed, Contextual, and Informative Bandit Methods for Clinical and Quantum Settings}
-\author[P. Z. Garcia]{Piter Z. Garcia Bautista}
-\institute[RIT]{Rochester Institute of Technology\\MS Data Science / Decision-Making \& Algorithmic Fairness}
-\date{DSCI 601 Final Presentation}
+\subtitle{Clinical and Quantum Sequential Decision Systems with MAB, CMAB, and iCMAB Methods}
+\author[P. Z. Garcia Bautista]{Piter Z. Garcia Bautista\\Advisors: Daniel Krutz and Travis Desell}
+\institute[RIT]{Rochester Institute of Technology\\DSCI 601 -- Applied Data Science I}
+\date{Endterm Presentation}
 
 \definecolor{ritorange}{RGB}{247,105,2}
 \definecolor{deepblue}{RGB}{31,78,121}
 \definecolor{softgreen}{RGB}{72,160,98}
 \definecolor{softred}{RGB}{190,75,72}
 \definecolor{softgray}{RGB}{245,247,250}
+\definecolor{softblue}{RGB}{88,137,174}
+\definecolor{softpurple}{RGB}{135,99,171}
 
 \setbeamercolor{title}{fg=deepblue}
 \setbeamercolor{frametitle}{fg=deepblue}
@@ -34,6 +37,7 @@
 \newcommand{\cmab}{\textsc{CMAB}}
 \newcommand{\icmab}{\textsc{iCMAB}}
 \newcommand{\sds}{\textsc{SDS}}
+\newcommand{\equitas}{\textsc{EQUITAS}}
 
 \begin{document}
 
@@ -43,319 +47,434 @@
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Presentation Roadmap}
+\begin{frame}{15-Minute Presentation Plan}
 \begin{enumerate}
-    \item Problem: sequential decisions under missing context
-    \item Real-world grounding: COVID test allocation and pulse oximetry bias
-    \item Proposed approach: fair contextual bandits over a selected MAB spectrum
-    \item Framework: clinical and quantum routing through a shared evaluator
-    \item Preliminary evidence, validation, and next work
+    \item Project overview: problem, goal, and contribution.
+    \item Updated domain model: clinical and quantum routing as one missing-context problem.
+    \item Updated architecture overview and four architecture layer slides.
+    \item GitHub code-review break: classes connected to the architecture.
+    \item Working demo plan and preliminary results.
+    \item Next-semester completion plan.
 \end{enumerate}
-\end{frame}
-
-% -----------------------------------------------------------------------------
-\begin{frame}{Scientific Merit: Sequential Decision Systems}
-\begin{block}{Core setting}
-Many applied data science systems are \textbf{sequential decision systems (SDSs)} that route scarce resources under uncertainty.
-\end{block}
-
 \vspace{0.5em}
-\begin{columns}[T]
-\begin{column}{0.48\textwidth}
-\textbf{Clinical examples}
-\begin{itemize}
-    \item Which patient receives a scarce diagnostic test?
-    \item Which case is escalated or retested?
-    \item Which model/pipeline should be trusted?
-\end{itemize}
-\end{column}
-\begin{column}{0.48\textwidth}
-\textbf{Quantum examples}
-\begin{itemize}
-    \item Which route receives entanglement-generation effort?
-    \item Which path receives scarce qubit capacity?
-    \item Which allocator performs best under noisy links?
-\end{itemize}
-\end{column}
-\end{columns}
-
-\vspace{0.5em}
-\alert{Challenge:} the chosen action reveals an outcome, but unchosen alternatives remain counterfactual.
+\begin{block}{Rubric alignment}
+The deck prioritizes clear figures, background explanation, an updated domain model, layered architecture, code review, and a demo path.
+\end{block}
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Why Context Matters for Fairness}
-\begin{block}{Failure mode}
-A policy optimized only for aggregate reward can hide subgroup errors and compound disparities over time when one group has delayed testing, incomplete history, lower-quality measurements, or less representative calibration data.
+\begin{frame}{Project Overview}
+\begin{block}{Problem}
+Many applied data science systems are \textbf{sequential decision systems}: they route scarce resources under uncertainty, observe only partial feedback, and update future decisions from incomplete evidence.
 \end{block}
 
-\vspace{0.5em}
-\begin{center}
-\begin{tikzpicture}[node distance=1.2cm, every node/.style={align=center}]
-\node[draw, rounded corners, fill=softgray, minimum width=2.8cm, minimum height=0.8cm] (ctx) {Uneven\\context quality};
-\node[draw, rounded corners, fill=softgray, right=1.2cm of ctx, minimum width=2.8cm, minimum height=0.8cm] (learn) {Partial-feedback\\learning};
-\node[draw, rounded corners, fill=softgray, right=1.2cm of learn, minimum width=2.8cm, minimum height=0.8cm] (alloc) {Repeated\\allocation};
-\node[draw, rounded corners, fill=softred!18, right=1.2cm of alloc, minimum width=2.8cm, minimum height=0.8cm] (harm) {Compounded\\disparity};
-\draw[-{Stealth}, thick] (ctx) -- (learn);
-\draw[-{Stealth}, thick] (learn) -- (alloc);
-\draw[-{Stealth}, thick] (alloc) -- (harm);
-\end{tikzpicture}
-\end{center}
-
-\vspace{0.4em}
-\textbf{Research idea:} treat context, performance, and fairness as coupled outcomes in the same sequential decision process.
-\end{frame}
-
-% -----------------------------------------------------------------------------
-\begin{frame}{Real-World Grounding: COVID Test Allocation}
-\begin{columns}[T]
-\begin{column}{0.54\textwidth}
-\textbf{Claim 1: Missing or ignored allocation context}
-\begin{itemize}
-    \item Early COVID-19 testing resources were scarce.
-    \item Allocation failed to adequately incorporate vulnerability context: race/ethnicity, SVI, burden, and access barriers.
-    \item Result: mismatch between testing access and community need.
-\end{itemize}
-\end{column}
-\begin{column}{0.42\textwidth}
-\begin{block}{Key quantitative finding}
-For every \textbf{1 percentage-point} increase in Hispanic underrepresentation in testing-site ZIP codes, the Hispanic share of COVID-19 deaths in later weeks was approximately \textbf{1.04 percentage points higher} than expected.
-\end{block}
-\end{column}
-\end{columns}
-
-\vspace{0.6em}
-\footnotesize Sources summarized in \texttt{docs/covid\_context\_case\_studies.md}: Bilal et al. (2021), Escobar et al. (2021), CDC MMWR, CDC SVI, Landes et al. (2020).
-\end{frame}
-
-% -----------------------------------------------------------------------------
-\begin{frame}{COVID Test Allocation as a Bandit Problem}
 \begin{columns}[T]
 \begin{column}{0.48\textwidth}
-\textbf{Decision unit}
+\textbf{Clinical routing}
 \begin{itemize}
-    \item Community node: ZIP code, county, or service region
-    \item Context: cases, deaths, positivity, race/ethnicity, SVI, poverty, crowding, age, essential-worker share
-    \item Arm: testing allocation level
+    \item diagnostic tests and retests
+    \item triage escalation
+    \item model-assisted prioritization
+    \item scarce attention during volatile conditions
 \end{itemize}
 \end{column}
 \begin{column}{0.48\textwidth}
-\textbf{Evaluation}
+\textbf{Quantum routing}
 \begin{itemize}
-    \item Reward: infections detected or deaths-averted proxy
-    \item Fairness: tests per 1,000, tests per detected case, disparity ratio by group/SVI
-    \item Risk: non-contextual allocation can reproduce convenience-based inequity
+    \item route selection
+    \item qubit allocation
+    \item entanglement-generation effort
+    \item noisy and non-stationary links
 \end{itemize}
-\end{column}
-\end{columns}
-
-\vspace{0.8em}
-\begin{center}
-\small
-\begin{tabular}{lll}
-\toprule
-Policy & Uses context? & Uses fairness signal? \\
-\midrule
-Non-contextual baseline & No & No \\
-Contextual utility-only & Yes & No \\
-Fairness-aware \icmab & Yes & Yes \\
-\bottomrule
-\end{tabular}
-\end{center}
-\end{frame}
-
-% -----------------------------------------------------------------------------
-\begin{frame}{Real-World Grounding: Pulse Oximetry Bias}
-\begin{columns}[T]
-\begin{column}{0.55\textwidth}
-\textbf{Claim 2: Missing group context at evaluation time}
-\begin{itemize}
-    \item Pulse oximetry was widely used for COVID triage and monitoring.
-    \item Devices overestimated oxygen saturation more often in darker-skinned patients.
-    \item This produced occult hypoxemia and delayed treatment eligibility.
-\end{itemize}
-\end{column}
-\begin{column}{0.41\textwidth}
-\begin{block}{Empirical pattern}
-Black patients were reported as roughly \textbf{3 times more likely} than White patients to have occult hypoxemia in the original NEJM evidence base.
-\end{block}
-\begin{block}{Scale}
-Later work included \textbf{24,504} patients with paired SpO$_2$/SaO$_2$ measurements.
-\end{block}
 \end{column}
 \end{columns}
 
 \vspace{0.4em}
-\footnotesize Sources summarized in \texttt{docs/covid\_context\_case\_studies.md}: Sjoding et al. (2020), Fawzy et al. (2022, 2023), Valbuena et al. (2022), VA ESP (2022), Gottlieb et al. (2022).
+\alert{Goal:} compare performance and fairness across non-contextual, contextual, and informative contextual bandit policies.
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Pulse Oximetry as a Bandit Problem}
+\begin{frame}{Clinical Validation Added This Semester}
+\begin{block}{New empirical foundation}
+The COVID clinical evidence analysis validates two concrete missing-context failures that directly motivate this research.
+\end{block}
+
 \begin{columns}[T]
 \begin{column}{0.48\textwidth}
-\textbf{Decision unit}
+\textbf{Case 1: Test allocation}
 \begin{itemize}
-    \item Patient encounter
-    \item Context: SpO$_2$, respiratory rate, heart rate, work of breathing, race/ethnicity, comorbidities
-    \item Arms: treat now, watch/wait, order confirmatory ABG
+    \item risk context existed but was not used well
+    \item high-SVI, Hispanic, and Black communities were under-served
+    \item fair CMAB routing reweights allocation by vulnerability
 \end{itemize}
 \end{column}
 \begin{column}{0.48\textwidth}
-\textbf{Evaluation}
+\textbf{Case 2: Diagnostic bias}
 \begin{itemize}
-    \item Reward: correct and timely treatment decisions
-    \item Fairness: group-wise occult hypoxemia rate
-    \item Constraint target: reduce disparity in missed hypoxemia across groups
+    \item pulse oximetry missed group-specific calibration context
+    \item Black, Hispanic, and Asian patients experienced higher occult hypoxemia
+    \item EQUITAS-style mediation can target the ambiguous decision zone
 \end{itemize}
 \end{column}
 \end{columns}
 
-\vspace{0.6em}
-\begin{equation*}
-\text{GWOHR}_g = P(\text{occult hypoxemia not caught} \mid \text{group}=g)
-\end{equation*}
-\begin{equation*}
-\max_g \text{GWOHR}_g - \min_g \text{GWOHR}_g \leq \epsilon
-\end{equation*}
+\vspace{0.4em}
+\small These cases show that context quality is not just metadata; it affects who receives resources and whose measurements can be trusted.
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Selected MAB Spectrum}
-\begin{block}{Spectrum evaluated in this work}
-Our MAB spectrum refers to the non-contextual, contextual, and informative contextual bandit families evaluated in the framework.
-\end{block}
-
-\vspace{0.5em}
-\begin{center}
-\begin{tabular}{p{0.23\textwidth}p{0.29\textwidth}p{0.34\textwidth}}
-\toprule
-Family & Decision signal & Expected risk under missing context \\
-\midrule
-\mab & action history only & may reinforce historical allocation bias \\
-\cmab & observed context & improves utility but can inherit biased or incomplete context \\
-\icmab & observed context + missingness/fairness information & tests whether context recovery and fairness mediation reduce harm \\
-\bottomrule
-\end{tabular}
-\end{center}
-\end{frame}
-
-% -----------------------------------------------------------------------------
-\begin{frame}{Shared Domain Model}
+\begin{frame}{Updated Domain Model}
 \begin{center}
 \begin{tikzpicture}[
-  node distance=1.0cm,
-  box/.style={draw, rounded corners, align=center, minimum width=2.45cm, minimum height=0.75cm, fill=softgray},
-  bad/.style={draw, rounded corners, align=center, minimum width=2.45cm, minimum height=0.75cm, fill=softred!18},
-  good/.style={draw, rounded corners, align=center, minimum width=2.45cm, minimum height=0.75cm, fill=softgreen!18}
+  node distance=0.9cm,
+  box/.style={draw, rounded corners, align=center, minimum width=2.35cm, minimum height=0.75cm, fill=softgray},
+  bad/.style={draw, rounded corners, align=center, minimum width=2.35cm, minimum height=0.75cm, fill=softred!18},
+  good/.style={draw, rounded corners, align=center, minimum width=2.35cm, minimum height=0.75cm, fill=softgreen!18},
+  arr/.style={-{Stealth}, thick}
 ]
 \node[box] (env) {Environment\\clinical / quantum};
-\node[bad, right=0.8cm of env] (ctx) {Missing, noisy,\\delayed context};
-\node[box, right=0.8cm of ctx] (policy) {Policy family\\\mab / \cmab / \icmab};
-\node[box, right=0.8cm of policy] (action) {Routing\\action};
-\node[good, below=0.9cm of action] (outcome) {Reward +\\fairness state};
-\node[box, left=0.8cm of outcome] (report) {Model-stratified\\reporting};
-\draw[-{Stealth}, thick] (env) -- (ctx);
-\draw[-{Stealth}, thick] (ctx) -- (policy);
-\draw[-{Stealth}, thick] (policy) -- (action);
-\draw[-{Stealth}, thick] (action) -- (outcome);
-\draw[-{Stealth}, thick] (outcome) -- (report);
-\draw[-{Stealth}, thick, dashed] (report.west) to[bend right=30] (policy.south);
+\node[bad, right=0.62cm of env] (ctx) {Observed context\\missing, noisy, delayed};
+\node[box, right=0.62cm of ctx] (policy) {Policy family\\\mab / \cmab / \icmab};
+\node[box, right=0.62cm of policy] (action) {Routing action\\test, triage, path};
+\node[good, below=0.85cm of action] (outcome) {Reward +\\fairness state};
+\node[box, left=0.62cm of outcome] (report) {Reporting +\\validation hub};
+\node[bad, left=0.62cm of report] (harm) {Disparity\\monitor};
+\draw[arr] (env) -- (ctx);
+\draw[arr] (ctx) -- (policy);
+\draw[arr] (policy) -- (action);
+\draw[arr] (action) -- (outcome);
+\draw[arr] (outcome) -- (report);
+\draw[arr] (report) -- (harm);
+\draw[arr, dashed] (harm.west) to[bend right=35] (policy.south);
 \end{tikzpicture}
 \end{center}
 
-\vspace{0.5em}
-\textbf{Key point:} the same failure mechanism appears in both domains: context quality determines what the learner can see, what it chooses, and which groups absorb the harm.
+\vspace{0.4em}
+\begin{itemize}
+    \item Multiplicity: one environment produces many contexts; one policy selects one action per round; one action produces one observed reward but many unobserved counterfactuals.
+    \item Fairness risk appears when context quality is systematically worse for one group, site, cohort, flow, or route class.
+\end{itemize}
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Framework Contribution}
+\begin{frame}{Updated Architecture Overview}
+\begin{center}
+\begin{tikzpicture}[
+  layer/.style={draw, rounded corners, align=center, minimum width=10.2cm, minimum height=0.75cm, fill=softgray},
+  arr/.style={-{Stealth}, thick, deepblue}
+]
+\node[layer, fill=softblue!18] (data) {Layer 1: Evidence, Data, and Context -- COVID evidence, clinical fixture, quantum saved states};
+\node[layer, fill=softgreen!18, below=0.32cm of data] (env) {Layer 2: Environments and Evaluators -- ClinicalEnvironment, quantum testbed, runners};
+\node[layer, fill=ritorange!18, below=0.32cm of env] (policy) {Layer 3: Policies and Allocation -- Baseline, FairAllocatorV1, ClinicalBanditUCB};
+\node[layer, fill=softpurple!18, below=0.32cm of policy] (report) {Layer 4: EQUITAS, Reporting, and Validation -- fairness states, summaries, artifacts};
+\draw[arr] (data) -- (env);
+\draw[arr] (env) -- (policy);
+\draw[arr] (policy) -- (report);
+\end{tikzpicture}
+\end{center}
+
+\vspace{0.4em}
+\begin{block}{Design principle}
+Low coupling: each layer exposes records/artifacts to the next layer. High cohesion: each layer has one job: context, environment, decision, or validation.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Architecture Layer 1: Evidence, Data, and Context}
 \begin{columns}[T]
 \begin{column}{0.48\textwidth}
-\textbf{Quantum path}
+\textbf{Inputs}
 \begin{itemize}
-    \item Preserves legacy quantum testbed and saved-state conventions.
-    \item Adds governed fairness artifacts through a sidecar/compatibility path.
-    \item Supports fairness evaluation without breaking existing quantum runs.
+    \item COVID clinical evidence report
+    \item clinical synthetic fixture
+    \item EQUITAS context fields
+    \item quantum legacy saved states
 \end{itemize}
 \end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Context fields}
+\begin{itemize}
+    \item group, site, cohort, service line
+    \item test distribution and escalation action
+    \item reward, success, latency
+    \item route choice, allocator, evaluator state
+\end{itemize}
+\end{column}
+\end{columns}
+
+\vspace{0.6em}
+\begin{block}{Why this layer matters}
+The COVID evidence makes the clinical context concrete: vulnerability, representation, and measurement quality must be modeled before a fair policy can act.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Architecture Layer 2: Environments and Evaluators}
+\begin{columns}[T]
 \begin{column}{0.48\textwidth}
 \textbf{Clinical path}
 \begin{itemize}
-    \item Runs as embedded evaluator: environment, runner, allocator, model registry, EQUITAS mediation.
-    \item Supports multiple clinical model families.
-    \item Produces model-stratified fairness summaries and report artifacts.
+    \item \texttt{ClinicalEnvironment}
+    \item \texttt{ClinicalExperimentRunner}
+    \item \texttt{ClinicalExperimentEvaluator}
+    \item synthetic clinical resource-allocation fixture
+\end{itemize}
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Quantum path}
+\begin{itemize}
+    \item existing quantum-routing testbed
+    \item evaluator/runner saved-state conventions
+    \item fairness sidecar artifacts
+    \item compatibility with legacy experiments
 \end{itemize}
 \end{column}
 \end{columns}
 
-\vspace{0.7em}
-\begin{block}{Contribution}
-A reproducible framework for comparing context, fairness, and performance across two structurally similar but domain-distinct routing systems.
+\vspace{0.6em}
+\begin{block}{Layer relationship}
+The evaluator standardizes outcome records so clinical and quantum runs can be compared through the same reporting and validation surface.
 \end{block}
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Preliminary Framework Evidence}
+\begin{frame}{Architecture Layer 3: Policies and Allocation}
 \begin{center}
-\begin{tabular}{p{0.42\textwidth}p{0.42\textwidth}}
+\begin{tabular}{p{0.24\textwidth}p{0.28\textwidth}p{0.35\textwidth}}
 \toprule
-Evidence item & Status / finding \\
+Policy family & Decision signal & Fairness risk \\
 \midrule
-Clinical embedded path & runs through evaluator, runner, environment, allocator, models, and EQUITAS context \\
-Clinical fairness smoke & produced 16 fairness states across Oracle, ClinicalBaseline, FairAllocatorV1, and ClinicalBanditUCB \\
-Non-oracle clinical efficiency & FairAllocatorV1: 91.23\%; ClinicalBanditUCB: 84.21\%; ClinicalBaseline: 75.09\% oracle efficiency \\
-Reporting layer & generated model-stratified fairness summaries and manifest-linked artifacts \\
-Quantum compatibility & legacy quantum path preserved while fairness artifacts are attached \\
+\mab & action history only & can repeat historical allocation patterns \\
+\cmab & observed context & can inherit incomplete or biased context \\
+\icmab & context + missingness/fairness state & can test whether mediated context reduces harm \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\vspace{0.6em}
+\begin{block}{Clinical model families used in smoke validation}
+Oracle, ClinicalBaseline, FairAllocatorV1, and ClinicalBanditUCB.
+\end{block}
+
+\begin{equation*}
+\text{decision}_t = \arg\max_a \left[\text{utility}_{t,a} - \lambda \cdot \text{expected disparity}_{t,a}\right]
+\end{equation*}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Architecture Layer 4: EQUITAS, Reporting, and Validation}
+\begin{columns}[T]
+\begin{column}{0.48\textwidth}
+\textbf{EQUITAS mediation}
+\begin{itemize}
+    \item attaches audit/mitigation context
+    \item tracks group-conditioned outcomes
+    \item separates artifact validation from unvalidated active quantum updates
+\end{itemize}
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Reporting layer}
+\begin{itemize}
+    \item model-stratified fairness summaries
+    \item manifest-linked report artifacts
+    \item validation hub checks evidence claims
+\end{itemize}
+\end{column}
+\end{columns}
+
+\vspace{0.6em}
+\begin{block}{Preliminary framework validation}
+The clinical fairness smoke produced 16 fairness states; report generation produced 21 manifest-linked artifacts.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Clinical Evidence Graph 1: Context-Blind vs Fair Test Routing}
+\begin{center}
+\begin{tikzpicture}
+\begin{axis}[
+    ybar,
+    width=0.95\textwidth,
+    height=0.58\textheight,
+    ymin=0,
+    ymax=10,
+    ylabel={Tests per 1,000 / week},
+    symbolic x coords={Hispanic,Black,Mixed,White,Low-Mixed},
+    xtick=data,
+    x tick label style={rotate=25,anchor=east,font=\scriptsize},
+    bar width=7pt,
+    legend style={at={(0.5,1.05)},anchor=south,legend columns=2,font=\scriptsize},
+    nodes near coords,
+    every node near coord/.append style={font=\tiny,rotate=90,anchor=west}
+]
+\addplot coordinates {(Hispanic,2.1) (Black,2.7) (Mixed,3.1) (White,8.9) (Low-Mixed,7.4)};
+\addplot coordinates {(Hispanic,8.4) (Black,7.9) (Mixed,6.8) (White,4.2) (Low-Mixed,3.8)};
+\legend{Actual routing,Fair CMAB target}
+\end{axis}
+\end{tikzpicture}
+\end{center}
+\vspace{-0.5em}
+\small High-SVI Hispanic, Black, and mixed communities receive more tests under context-aware allocation; low-SVI communities receive fewer because their burden index is lower. This turns context into routing evidence rather than post-hoc explanation.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Clinical Evidence Graph 2: Pulse Oximetry Diagnostic Bias}
+\begin{center}
+\begin{tikzpicture}
+\begin{axis}[
+    ybar,
+    width=0.95\textwidth,
+    height=0.58\textheight,
+    ymin=0,
+    ymax=32,
+    ylabel={Occult hypoxemia rate (\%)},
+    symbolic x coords={White,Hispanic,Asian,Black},
+    xtick=data,
+    bar width=6pt,
+    legend style={at={(0.5,1.05)},anchor=south,legend columns=3,font=\scriptsize},
+    nodes near coords,
+    every node near coord/.append style={font=\tiny,rotate=90,anchor=west}
+]
+\addplot coordinates {(White,3.6) (Hispanic,5.1) (Asian,6.3) (Black,11.7)};
+\addplot coordinates {(White,16.7) (Hispanic,21.4) (Asian,24.1) (Black,29.0)};
+\addplot coordinates {(White,14.2) (Hispanic,19.8) (Asian,22.1) (Black,25.6)};
+\legend{Sjoding 2020,Fawzy 2022,Fawzy 2023}
+\end{axis}
+\end{tikzpicture}
+\end{center}
+\vspace{-0.4em}
+\small Across independent studies, Black patients show the highest missed-hypoxemia risk, followed by Asian and Hispanic patients. The same device and threshold produce unequal diagnostic reliability.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Confusion-Matrix Finding: Diagnostic Reliability Is Unequal}
+\begin{columns}[T]
+\begin{column}{0.48\textwidth}
+\textbf{Baseline single threshold}
+\begin{center}
+\small
+\begin{tabular}{lcc}
+\toprule
+ & Caught & Missed \\
+\midrule
+White occult hypoxemia & 96\% & 4\% \\
+Black occult hypoxemia & 71\% & 29\% \\
+\bottomrule
+\end{tabular}
+\end{center}
+\vspace{0.4em}
+\alert{Disparity:} about 25 percentage points in missed hypoxemia.
+\end{column}
+\begin{column}{0.48\textwidth}
+\textbf{Fair CMAB + EQUITAS target}
+\begin{center}
+\small
+\begin{tabular}{lcc}
+\toprule
+ & Caught & Missed \\
+\midrule
+White occult hypoxemia & 96\% & 4\% \\
+Black occult hypoxemia & 94\% & 6\% \\
+\bottomrule
+\end{tabular}
+\end{center}
+\vspace{0.4em}
+\alert{Target:} reduce the gap to less than 2 percentage points using targeted threshold/ABG mediation.
+\end{column}
+\end{columns}
+
+\vspace{0.6em}
+\begin{block}{Clinical interpretation}
+The fair policy does not need blanket overtesting. It targets the ambiguous SpO$_2$ zone where bias changes treatment eligibility.
+\end{block}
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{Preliminary Framework Results}
+\begin{center}
+\begin{tabular}{p{0.43\textwidth}p{0.42\textwidth}}
+\toprule
+Evidence item & Result \\
+\midrule
+Clinical embedded path & evaluator, runner, environment, allocator, models, and EQUITAS context run end-to-end \\
+Clinical fairness smoke & 16 fairness states across four model families \\
+Non-oracle efficiency & FairAllocatorV1: 91.23\%; ClinicalBanditUCB: 84.21\%; ClinicalBaseline: 75.09\% oracle efficiency \\
+Reporting layer & 21 manifest-linked artifacts and model-stratified summaries \\
+Quantum compatibility & legacy quantum path preserved with fairness sidecar artifacts \\
+\bottomrule
+\end{tabular}
+\end{center}
+\vspace{0.3em}
+\small Boundary: active fairness-adjusted quantum learning still requires an explicit policy-update mechanism and full validation.
+\end{frame}
+
+% -----------------------------------------------------------------------------
+\begin{frame}{GitHub Code Review Break}
+\begin{block}{Show 2--3 classes not used in the midterm}
+During the live code break, open GitHub and connect each class to the architecture diagram.
+\end{block}
+
+\begin{center}
+\small
+\begin{tabular}{p{0.32\textwidth}p{0.48\textwidth}}
+\toprule
+Class / file to show & Architecture connection \\
+\midrule
+\texttt{ClinicalExperimentEvaluator} & Layer 2 evaluator orchestration and artifact capture \\
+\texttt{ClinicalExperimentRunner} & Layer 2 run execution over seeds, models, and allocations \\
+\texttt{FairAllocatorV1} or \texttt{ClinicalBanditUCB} & Layer 3 policy/allocation decision logic \\
+\texttt{equitas\_mediator.py} & Layer 4 fairness audit and mitigation context \\
 \bottomrule
 \end{tabular}
 \end{center}
 
 \vspace{0.4em}
-\small These are preliminary framework-validation results; active fairness-adjusted quantum learning still requires an explicit policy-update mechanism and full validation.
+\small Mention comments, formatting, and how the classes expose low coupling/high cohesion across layers.
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{What the New COVID Analysis Adds}
-\begin{block}{Before}
-The project had a framework and cross-domain analogy, but the clinical motivation needed stronger empirical grounding.
-\end{block}
-
-\begin{block}{Now}
-The COVID case-study analysis supplies two concrete, evidence-backed clinical routing failures:
+\begin{frame}{Working Demo Plan}
 \begin{enumerate}
-    \item test allocation failed when risk and vulnerability context were ignored;
-    \item pulse oximetry failed when group/skin-tone context was missing from calibration and evaluation.
+    \item Run the clinical fairness demo or smoke validation notebook.
+    \item Show generated fairness states and model-stratified summaries.
+    \item Show report artifacts and manifest linkage.
+    \item Open the validation hub and point to the five validated evidence claims.
+    \item Explain how the COVID clinical evidence can become next-semester executable environments.
 \end{enumerate}
-\end{block}
 
-\begin{block}{Impact on presentation and paper}
-These cases make the clinical side real: missing context is not abstract; it caused measurable access, mortality, diagnostic, and treatment-delay harms.
+\vspace{0.6em}
+\begin{block}{Demo objective}
+Show that the system is not only conceptual: it runs, records fairness evidence, and produces artifacts connected to the architecture.
 \end{block}
 \end{frame}
 
 % -----------------------------------------------------------------------------
-\begin{frame}{Next Work}
+\begin{frame}{Next Semester: Architecture Completion}
 \begin{enumerate}
-    \item Convert COVID test-allocation and pulse-ox case studies into executable clinical environments.
-    \item Generate the planned figures: allocation network, group access bars, occult hypoxemia bars, bias bars, and fairness--utility tradeoff curve.
-    \item Complete model-family comparisons across the selected MAB spectrum.
-    \item Quantify which group is more likely to be harmed under non-stationary conditions.
-    \item Implement and validate active fairness-adjusted quantum policy updates.
+    \item Convert COVID test allocation and pulse-ox evidence into executable clinical environments.
+    \item Add publication-ready figures to the clinical evidence report and presentation pipeline.
+    \item Complete active fairness-adjusted quantum policy updates.
+    \item Extend validation hub into separate efficiency and fairness hubs.
+    \item Build a reporting layer that links framework outputs, validation evidence, and paper claims.
 \end{enumerate}
+\vspace{0.6em}
+\begin{block}{Longer-term goal}
+A portal-style reporting surface for queries, experiments, validation, and paper-ready evidence.
+\end{block}
 \end{frame}
 
 % -----------------------------------------------------------------------------
 \begin{frame}{Takeaway}
-\begin{block}{Main claim}
-Context quality is a fairness variable. When context is missing, ignored, or unevenly distributed, sequential decision systems can convert measurement gaps into repeated allocation harm.
+\begin{block}{Main scientific claim}
+Context quality is a fairness variable. Missing, ignored, or biased context can turn partial-feedback learning into repeated allocation harm.
 \end{block}
 
-\begin{block}{Project contribution}
-This work builds a clinical--quantum evaluation framework that compares performance and fairness across the selected MAB spectrum while preserving reproducibility and model-stratified evidence.
+\begin{block}{What was built}
+A clinical--quantum evaluation framework that compares performance and fairness across the selected MAB spectrum while preserving reproducible artifacts.
 \end{block}
 
-\begin{block}{Why it matters}
-The same methodology can study COVID test allocation, biased diagnostic triage, and quantum routing under scarce probabilistic resources.
+\begin{block}{What the new COVID analysis adds}
+COVID test allocation and pulse-ox bias provide real clinical evidence that validates the framework's missing-context harm model.
 \end{block}
 \end{frame}
 
@@ -365,11 +484,14 @@ The same methodology can study COVID test allocation, biased diagnostic triage, 
 \begin{thebibliography}{99}
 \bibitem{bilal2021} Bilal et al. Racial and ethnic inequities in the early distribution of U.S. COVID-19 testing sites. \textit{Social Science \& Medicine}, 2021.
 \bibitem{escobar2021} Escobar et al. Addressing COVID-19 testing inequities among underserved communities. 2021.
+\bibitem{cdcdisparities} CDC/NCHS. COVID-19 provisional counts: health disparities.
+\bibitem{millett2020} Millett et al. Assessing differential impacts of COVID-19 on Black communities. \textit{Annals of Epidemiology}, 2020.
 \bibitem{sjoding2020} Sjoding et al. Racial bias in pulse oximetry measurement. \textit{New England Journal of Medicine}, 2020.
 \bibitem{fawzy2022} Fawzy et al. Racial and ethnic discrepancy in pulse oximetry and delayed identification of treatment eligibility among patients with COVID-19. \textit{JAMA Internal Medicine}, 2022.
 \bibitem{fawzy2023} Fawzy et al. Clinical outcomes associated with overestimation of oxygen saturation by pulse oximetry. \textit{JAMA Network Open}, 2023.
-\bibitem{valbuena2022} Valbuena et al. Racial bias and reproducibility in pulse oximetry among medical and surgical inpatients in general care. \textit{BMJ}, 2022.
-\bibitem{garcia2026} Garcia Bautista. Threat-aware quantum routing evaluation / DSCI601 project materials, 2026.
+\bibitem{valbuena2022} Valbuena et al. Racial bias and reproducibility in pulse oximetry among medical and surgical inpatients. \textit{BMJ}, 2022.
+\bibitem{vaesp2022} VA Evidence Synthesis Program. Differential pulse oximeter accuracy, occult hypoxemia prevalence, and clinical outcomes by race/ethnicity.
+\bibitem{garcia2026} Garcia Bautista. DSCI601 project proposal, rough report, architecture, and fairness framework materials.
 \end{thebibliography}
 \end{frame}
 


### PR DESCRIPTION
## Summary

Adds a standalone Beamer `.tex` presentation for the DSCI 601 endterm presentation.

## What changed

- Adds `presentation/final_presentation.tex`.
- Aligns the deck with the uploaded endterm presentation rubric:
  - title slide
  - project overview
  - updated domain model
  - updated architecture overview
  - architecture layer slides
  - GitHub code-review break
  - working demo plan
  - next-semester completion plan
- Incorporates the new COVID clinical evidence analysis:
  - COVID test allocation as context-blind routing failure
  - pulse oximetry as missing calibration/context diagnostic bias
  - fair CMAB routing comparison chart
  - occult hypoxemia grouped bar chart
  - diagnostic reliability/confusion-matrix-style finding
- Connects evidence back to FairAllocatorV1, ClinicalBanditUCB, EQUITAS mediation, reporting artifacts, and validation claims.

## Notes

This PR only adds/updates presentation material. It does not modify the paper manuscript body.