### PR TITLE
Refine rough draft abstract and intro opening

### DIFF
--- a/rough_draft_report/abstract_intro_update.patch
+++ b/rough_draft_report/abstract_intro_update.patch
@@ -1,0 +1,60 @@
+diff --git a/rough_draft_report/rough_draft_report.tex b/rough_draft_report/rough_draft_report.tex
+--- a/rough_draft_report/rough_draft_report.tex
++++ b/rough_draft_report/rough_draft_report.tex
+@@
+-\begin{abstract}
+-Sequential decision systems increasingly determine how scarce diagnostic,
+-computational, and communication resources are routed under uncertainty. This
+-project studies fairness-aware contextual multi-armed bandits for such
+-decisions when context is missing, delayed, noisy, or group-dependent. The
+-central claim is that clinical diagnostic decision workflows and quantum
+-network routing share the same structural failure mode: policies must choose
+-an action from partial feedback, yet the groups or flows with the least
+-reliable context can absorb the worst errors. The work develops a reusable
+-evaluation framework for non-contextual bandits, contextual bandits, and
+-informative contextual bandits across two executable environment families. The
+-quantum path reuses the legacy quantum-routing evaluation stack and saved-state
+-paths from the quantum-routing evaluation paper, while the clinical path now
+-runs through an embedded synthetic clinical environment with clinical models,
+-resource allocation, EQUITAS mediation, and governed fairness artifacts. Work
+-completed so far includes the related-work synthesis, domain model,
+-architecture specification, embedded clinical evaluator path, legacy quantum
+-fairness sidecar, default and fairness reporting datasets, validation-hub
+-artifacts, and CI-protected smoke gates. The contribution is a reproducible method for
+-measuring and mitigating time-evolving fairness disparities while
+-preserving utility under non-stationarity and limited context.
+-\end{abstract}
++\begin{abstract}
++Sequential decision systems increasingly determine how scarce diagnostic,
++computational, and communication resources are routed under uncertainty. This
++study examines fairness-aware bandits across a decision spectrum, from
++non-contextual multi-armed bandits to contextual and informative contextual
++bandits, for settings where context is missing, delayed, noisy, or
++group-dependent. The central claim is that quantum routing and clinical
++diagnostic routing share a common sequential resource-allocation structure:
++policies must choose actions from partial feedback, yet groups or flows with
++the least reliable context can absorb the worst errors.
++
++The work develops a reusable evaluation framework for this bandit spectrum
++across two executable environment families. The quantum domain builds on a
++state-preserving quantum-routing evaluation stack, while the clinical domain
++uses an embedded synthetic clinical environment with resource allocation,
++clinical models, and EQUITAS-mediated fairness reporting. Preliminary quantum
++results show that predictive-context policies improve over no-context
++baselines by 3.74 percentage points internally and 2.83 percentage points
++externally. In the clinical setting, the embedded EQUITAS-aware allocator
++improves oracle-normalized efficiency from 75.09\% to 91.23\%, raises mean
++success from 50.0\% to 72.5\%, and reduces the latency parity gap from 18.0
++to 10.17 relative to the baseline. In the related bioinformatics proxy,
++context-aware scoring increases predicted-pair output from
++14.96 $\pm$ 10.45 to 61.36 $\pm$ 44.21, with optimized output reaching
++66.07 $\pm$ 46.36 and average disparate-impact improvement of +0.805 after
++augmentation. Together, these components define a method for measuring and
++mitigating time-evolving fairness disparities while preserving utility under
++non-stationarity and limited context.
++\end{abstract}
+@@
+-Many applied data science systems are not one-shot predictors. They are
+-sequential decision systems that route limited resources under uncertainty:
++Many applied data science systems are sequential decision systems that route
++limited resources under uncertainty:


### PR DESCRIPTION
## Summary
- Adds the agreed abstract/introduction update as a patch for the rough draft report.
- Captures the final abstract wording with the stronger preliminary quantum, clinical allocator, and bioinformatics proxy results.
- Captures the cleaner Introduction opening that removes the one-shot predictor framing.

## Note
This PR currently contains the patch file because the connector blocked the direct file rewrite during this session. The patch is scoped to `rough_draft_report/rough_draft_report.tex` and can be applied directly.