### PR TITLE
Context spectrum wrap-up edits

### DIFF
--- a/rough_draft_report/context_spectrum_wrapup_notes.txt
+++ b/rough_draft_report/context_spectrum_wrapup_notes.txt
@@ -1,0 +1,1 @@
+Context-spectrum wrap-up notes.


### PR DESCRIPTION
Adds a context-spectrum wrap-up branch with the agreed editing notes. Intended changes: move Algorithm 2 into Methodology before EQUITAS mediation, keep the wide context-spectrum trace table in the appendix, add page numbers for review, and update algorithm/table/figure references so Algorithm 2 links directly to Table context_spectrum and Figure context_spectrum.

Note: I was able to create the branch and add a notes file. The full TeX replacement still needs to be applied to rough_draft_report_validated_copy.tex or a new TeX copy because the connector write path could not safely update the existing file without the current blob SHA.